### PR TITLE
Fix multi attribute login issue when magic link authenticator as first factor

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/pom.xml
@@ -70,6 +70,10 @@
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.auth.attribute.handler</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
 
         <!--Test Dependencies-->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.agent</artifactId>
                 <classifier>runtime</classifier>
@@ -201,7 +207,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>
-        <carbon.identity.framework.version>5.25.245</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.252</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.3.14</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.4.126</identity.inbound.auth.oauth.version>
@@ -209,6 +215,8 @@
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <identity.governance.version>1.8.23</identity.governance.version>
+        <org.wso2.carbon.identity.organization.management.core.version>1.0.55
+        </org.wso2.carbon.identity.organization.management.core.version>
 
         <!--Test Dependencies-->
         <testng.version>6.9.10</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>
-        <carbon.identity.framework.version>5.23.18</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.245</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.3.14</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.4.126</identity.inbound.auth.oauth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>
-        <carbon.identity.framework.version>5.25.252</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.253</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.3.14</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.4.126</identity.inbound.auth.oauth.version>


### PR DESCRIPTION
### Changes from this PR 
- Use the newly introduced getUser method in AbstractApplicationAuthenticator class.
- This getUser method is used to resolve the users in the magic link authenticator in below two scenarios.
      -  magic link as first factor
      - IDF as first factor and  magic ink as second factor.


### Related issue
https://github.com/wso2/product-is/issues/16242