### PR TITLE
Improve magic link authenticator to send init IDF query param

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
@@ -141,8 +141,9 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
                 }
                 response.sendRedirect(loginPage + ("?" + queryParams)
                         + MagicLinkAuthenticatorConstants.AUTHENTICATORS +
-                        MagicLinkAuthenticatorConstants.IDF_HANDLER_NAME + ":" +
-                        MagicLinkAuthenticatorConstants.LOCAL);
+                        MagicLinkAuthenticatorConstants.AUTHENTICATOR_NAME + ":" +
+                        MagicLinkAuthenticatorConstants.LOCAL +
+                        "&" + FrameworkConstants.RequestParams.INITIATE_IDENTIFIER_FIRST + "=true");
             } catch (IOException e) {
                 org.wso2.carbon.identity.application.common.model.User user =
                         org.wso2.carbon.identity.application.common.model.User

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.A
 import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
 import org.wso2.carbon.identity.application.authentication.framework.internal.FrameworkServiceDataHolder;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.magiclink.cache.MagicLinkAuthContextCache;
 import org.wso2.carbon.identity.application.authenticator.magiclink.cache.MagicLinkAuthContextCacheEntry;
@@ -461,8 +462,9 @@ public class MagicLinkAuthenticatorTest {
         magicLinkAuthenticator.initiateAuthenticationRequest(httpServletRequest, httpServletResponse, context);
         assertEquals(redirect, DUMMY_LOGIN_PAGEURL + ("?" + DUMMY_QUERY_PARAMS)
                 + MagicLinkAuthenticatorConstants.AUTHENTICATORS +
-                MagicLinkAuthenticatorConstants.IDF_HANDLER_NAME + ":" +
-                MagicLinkAuthenticatorConstants.LOCAL);
+                MagicLinkAuthenticatorConstants.AUTHENTICATOR_NAME + ":" +
+                MagicLinkAuthenticatorConstants.LOCAL +
+                "&" + FrameworkConstants.RequestParams.INITIATE_IDENTIFIER_FIRST + "=true");
     }
 
     @Test(description = "Test case for initiateAuthenticationRequest() method identifier first flow.")

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>
-        <carbon.identity.framework.version>5.25.253</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.259-SNAPSHOT</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.3.14</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.4.126</identity.inbound.auth.oauth.version>


### PR DESCRIPTION
**Purpose**
Magic link authenticator supports first factor login. That is through the self-contained IDF improvement. In there we have the user resolving logic at the authenticator, however the user identifier is retrieved using the Identifier first frontend code. This is done with the `authenticators` request parameter passed with the value of `IdentifierExecutor:LOCAL`. Due to this some flows recognize this as IDF being in the authentication sequence and raise issues.

This PR fixes it by removing the `IdentifierExecutor:LOCAL` value from the authenticators parameter and introducing a new query parameter to trigger the IDF frontend.

*Related Issue*
- https://github.com/wso2/product-is/issues/16321

**Related PRs**
- https://github.com/wso2/carbon-identity-framework/pull/4812
