### PR TITLE
Add diagnostic logs

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>org.wso2.carbon.identity.event</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.event.handler.notification</groupId>
             <artifactId>org.wso2.carbon.email.mgt</artifactId>
         </dependency>
@@ -120,8 +124,10 @@
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.event.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.utils; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.utils; version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
@@ -554,16 +554,15 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
 
     private Optional<String> getUserId(AuthenticationContext context) {
 
-        if (context.getSubject() == null) {
-            return Optional.empty();
-        }
-        try {
-            return Optional.ofNullable(context.getSubject().getUserId());
-        } catch (UserIdNotFoundException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error while getting the user id from the subject.", e);
+        return Optional.ofNullable(context.getSubject()).map(authenticatedUser -> {
+            try {
+                return authenticatedUser.getUserId();
+            } catch (UserIdNotFoundException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Error while getting the user id from the subject.", e);
+                }
+                return null;
             }
-            return Optional.empty();
-        }
+        });
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorConstants.java
@@ -48,5 +48,23 @@ public abstract class MagicLinkAuthenticatorConstants {
     public static final String TEMPLATE_TYPE = "TEMPLATE_TYPE";
     public static final String EVENT_NAME = "magicLink";
     public static final String EXPIRYTIME = "expiry-time";
+
+    /**
+     * Constants related to log management.
+     */
+    public static class LogConstants {
+
+        public static final String MAGIC_LINK_AUTH_SERVICE = "local-auth-magiclink";
+
+        /**
+         * Define action IDs for diagnostic logs.
+         */
+        public static class ActionIDs {
+
+            public static final String SEND_MAGIC_LINK = "send-magiclink-token";
+            public static final String PROCESS_AUTHENTICATION_RESPONSE = "process-authentication-response";
+            public static final String VALIDATE_MAGIC_LINK_REQUEST = "validate-authentication-request";
+        }
+    }
 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
@@ -45,6 +45,7 @@ import org.wso2.carbon.identity.application.authenticator.magiclink.cache.MagicL
 import org.wso2.carbon.identity.application.authenticator.magiclink.cache.MagicLinkAuthContextCacheKey;
 import org.wso2.carbon.identity.application.authenticator.magiclink.internal.MagicLinkServiceDataHolder;
 import org.wso2.carbon.identity.application.authenticator.magiclink.model.MagicLinkAuthContextData;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -81,7 +82,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 @PrepareForTest({ TokenGenerator.class, IdentityUtil.class, ServiceURLBuilder.class, IdentityTenantUtil.class,
         AbstractUserStoreManager.class, MagicLinkAuthContextCache.class, MagicLinkServiceDataHolder.class,
         ConfigurationFacade.class, FrameworkUtils.class, MultitenantUtils.class, UserCoreUtil.class,
-        FrameworkServiceDataHolder.class})
+        FrameworkServiceDataHolder.class, LoggerUtils.class })
 @PowerMockIgnore({ "javax.net.*", "javax.security.*", "javax.crypto.*", "javax.xml.*" })
 public class MagicLinkAuthenticatorTest {
 
@@ -140,6 +141,8 @@ public class MagicLinkAuthenticatorTest {
         Whitebox.setInternalState(magicLinkAuthenticator, "authenticationContext", context);
         frameworkServiceDataHolder = mock(FrameworkServiceDataHolder.class);
         mockStatic(FrameworkServiceDataHolder.class);
+        mockStatic(LoggerUtils.class);
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(false);
     }
 
     private void mockServiceURLBuilder() {

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
@@ -64,9 +64,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -95,6 +97,8 @@ public class MagicLinkAuthenticatorTest {
     private static final String DEFAULT_SERVER_URL = "http://localhost:9443";
     private static final String DUMMY_LOGIN_PAGEURL = "dummyLoginPageurl";
     private static final String DUMMY_QUERY_PARAMS = "dummyQueryParams";
+    private static final String DUMMY_APP_NAME = "dummyAppName";
+    private static final String DUMMY_APP_RESOURCE_ID = "dummyAppResourceId";
     private MagicLinkAuthenticator magicLinkAuthenticator;
     private String redirect;
 
@@ -142,7 +146,10 @@ public class MagicLinkAuthenticatorTest {
         frameworkServiceDataHolder = mock(FrameworkServiceDataHolder.class);
         mockStatic(FrameworkServiceDataHolder.class);
         mockStatic(LoggerUtils.class);
-        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(false);
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
+        mockStatic(FrameworkUtils.class);
+        when(FrameworkUtils.getApplicationName(any())).thenReturn(Optional.of(DUMMY_APP_NAME));
+        when(FrameworkUtils.getApplicationResourceId(any())).thenReturn(Optional.of(DUMMY_APP_RESOURCE_ID));
     }
 
     private void mockServiceURLBuilder() {

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.event.handler.notification</groupId>
                 <artifactId>org.wso2.carbon.email.mgt</artifactId>
                 <version>${identity.event.handler.notification.version}</version>
@@ -206,8 +211,8 @@
     <properties>
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
-        <carbon.kernel.version>4.7.0</carbon.kernel.version>
-        <carbon.identity.framework.version>5.25.253</carbon.identity.framework.version>
+        <carbon.kernel.version>4.9.10</carbon.kernel.version>
+        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.3.14</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.4.126</identity.inbound.auth.oauth.version>


### PR DESCRIPTION
## Purpose
* $subject

### Approach

![image](https://github.com/wso2-enterprise/asgardeo-product/assets/32576163/ceea5959-581e-47aa-b7b2-6962861a2b2d)

Diagnostic logs will be covered the green-colored actions/validations of the authentication process. 
1. Authentication Request Validation
Within each authenticator, the `initiateAuthenticationRequest` method houses the logic for this step. This triggers two diagnostic logs. The first log indicates when authentication validation starts, and the second log shows the result of the validation – whether it's a Success or marked Invalid.

2. Validate Authentication Response
The `processAuthenticationResponse` method handles authentication response validation. Once users are sent to the authentication page and complete the process, the authenticator receives an authentication response, which this method manages. Just like the request validation, this step also generates two diagnostic logs. The first one marks the beginning of response validation, while the second one is only created if the authentication is successful. We've chosen not to include logs for authentication response failures for a couple of reasons:
- Numerous potential failure scenarios across authenticators make adding logs for each too complicated and code-heavy.
- With https://github.com/wso2/carbon-identity-framework/pull/4809, there's a common log in place that covers and reports authentication response failures caused by authenticators.

Additionally, there will be another diagnostic log that will get published from the canHandle() method of each authenticator. The `canHandle` method gets executed each time before the `initiateAuthenticationRequest` and `processAuthenticationResponse` get executed. This log is published as an internal log for our internal developers. The purpose of this log is to verify whether the auth request/response was passed into the authenticator to handle it.