### PR TITLE
Added multiOptionURI parameter to the redirect url in the magic-link authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/pom.xml
@@ -78,6 +78,10 @@
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+        </dependency>
 
         <!--Test Dependencies-->
         <dependency>
@@ -133,6 +137,7 @@
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.auth.attribute.handler.*;
                             version="${identity.governance.imp.pkg.version.range}",
+                            org.owasp.encoder; version="${encoder.wso2.import.version.range}",
                         </Import-Package>
                         <Private-Package>
                             org.wso2.carbon.identity.application.authenticator.magiclink.internal,

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.A
 import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AdditionalData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorMessage;

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
@@ -22,6 +22,7 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.owasp.encoder.Encode;
 import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.LocalApplicationAuthenticator;
@@ -31,7 +32,6 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.A
 import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
-import org.wso2.carbon.identity.application.authentication.framework.model.AdditionalData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorMessage;
@@ -79,9 +79,9 @@ import static org.wso2.carbon.identity.application.authenticator.magiclink.Magic
 import static org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants.LogConstants.ActionIDs.VALIDATE_MAGIC_LINK_REQUEST;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants.LogConstants.MAGIC_LINK_AUTH_SERVICE;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants.MAGIC_LINK_TOKEN;
+import static org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants.MULTI_OPTION_QUERY_PARAM;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants.USERNAME_PARAM;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants.USER_NAME;
-import static org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants.USER_PROMPT;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants.MLT;
 
 /**
@@ -171,6 +171,7 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
             context.setProperty(MagicLinkAuthenticatorConstants.IS_IDF_INITIATED_FROM_AUTHENTICATOR, true);
             String loginPage = ConfigurationFacade.getInstance().getAuthenticationEndpointURL();
             String queryParams = context.getContextIdIncludedQueryParams();
+            String multiOptionURI = getMultiOptionURIQueryParam(request);
             try {
                 if (log.isDebugEnabled()) {
                     String logMsg = String.format("Redirecting to identifier first flow since " +
@@ -179,7 +180,8 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
                     log.debug(logMsg);
                 }
                 String redirectUri = loginPage + ("?" + queryParams) + MagicLinkAuthenticatorConstants.AUTHENTICATORS +
-                        MagicLinkAuthenticatorConstants.IDF_HANDLER_NAME + ":" + MagicLinkAuthenticatorConstants.LOCAL;
+                        MagicLinkAuthenticatorConstants.IDF_HANDLER_NAME + ":" + MagicLinkAuthenticatorConstants.LOCAL
+                        + multiOptionURI;
                 response.sendRedirect(redirectUri);
                 if (LoggerUtils.isDiagnosticLogsEnabled() && finalDiagnosticLogBuilder != null) {
                     finalDiagnosticLogBuilder.resultMessage("Redirecting to identifier first flow since the last " +
@@ -673,5 +675,21 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
                 0, Boolean.FALSE, USERNAME_PARAM);
         authenticatorParamMetadataList.add(usernameMetadata);
         authenticatorData.setAuthParams(authenticatorParamMetadataList);
+    }
+
+    /**
+     * Get the multi option URI query params.
+     *
+     * @param request HttpServletRequest.
+     */
+    private static String getMultiOptionURIQueryParam(HttpServletRequest request) {
+
+        String multiOptionURI = "";
+        if (request != null) {
+            multiOptionURI = request.getParameter(MULTI_OPTION_QUERY_PARAM);
+            multiOptionURI = multiOptionURI != null ? "&" + MULTI_OPTION_QUERY_PARAM + "=" +
+                    Encode.forUriComponent(multiOptionURI) : "";
+        }
+        return multiOptionURI;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorConstants.java
@@ -56,6 +56,7 @@ public abstract class MagicLinkAuthenticatorConstants {
     public static final String EXPIRYTIME = "expiry-time";
     public static final String IS_API_BASED_AUTHENTICATION_SUPPORTED = "isAPIBasedAuthenticationSupported";
     public static final String CALLBACK_URL = "callbackUrl";
+    public static final String MULTI_OPTION_QUERY_PARAM = "multiOptionURI";
 
     /**
      * Constants related to log management.

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
                 <artifactId>org.wso2.carbon.identity.auth.attribute.handler</artifactId>
                 <version>${identity.governance.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+                <artifactId>encoder</artifactId>
+                <version>${owasp.encoder.version}</version>
+            </dependency>
 
             <!--Test Dependencies-->
             <dependency>
@@ -222,6 +227,7 @@
         <identity.governance.version>1.8.23</identity.governance.version>
         <org.wso2.carbon.identity.organization.management.core.version>1.0.55
         </org.wso2.carbon.identity.organization.management.core.version>
+        <owasp.encoder.version>1.2.0.wso2v1</owasp.encoder.version>
 
         <!--Test Dependencies-->
         <testng.version>6.9.10</testng.version>
@@ -241,6 +247,7 @@
         <carbon.kernel.imp.pkg.version.range>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <identity.governance.imp.pkg.version.range>[1.5.0, 3.0.0)</identity.governance.imp.pkg.version.range>
+        <encoder.wso2.import.version.range>[1.2.0, 2.0.0)</encoder.wso2.import.version.range>
 
         <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>


### PR DESCRIPTION
## #Purpose
> $subject
With this PR, the multiOptionURI parameter will be sent to the `identifierauth.jsp` and with that it will show the `Choose a different option` link which is allowing the user to go back to other authenticators in the respective authentication step. 


### Related Issue
- https://github.com/wso2/product-is/issues/17962

