### PR TITLE
Add state param for api based auth

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
@@ -65,6 +65,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.RESTART_FLOW;
@@ -212,6 +213,15 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
                 if (StringUtils.isNotEmpty(magicToken)) {
                     String expiryTime =
                             TimeUnit.SECONDS.toMinutes(getExpiryTime()) + " " + TimeUnit.MINUTES.name().toLowerCase();
+                    if (Boolean.parseBoolean((String) context.getProperty(IS_API_BASED))) {
+                        /* Setting a state param to the request for the client to be able to correlate the
+                        magic link coming to the app in API based authentication flow. The code is written in
+                        this manner as it is not possible to dynamically set params to the email template. */
+                        String state = UUID.randomUUID().toString();
+                        context.setProperty(MagicLinkAuthenticatorConstants.AUTHENTICATOR_NAME +
+                                MagicLinkAuthenticatorConstants.STATE_PARAM_SUFFIX, state);
+                        magicToken = magicToken + "&" + MagicLinkAuthenticatorConstants.STATE_PARAM + "=" + state;
+                    }
                     triggerEvent(user, context, magicToken, expiryTime);
                 }
             }
@@ -660,6 +670,13 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
             requiredParams.add(MLT);
             authenticatorData.setRequiredParams(requiredParams);
             setAuthParams(authenticatorData);
+            Map<String, String> additionalAuthenticationParams = new HashMap<>();
+            String state = (String) context.getProperty(MagicLinkAuthenticatorConstants.AUTHENTICATOR_NAME +
+                    MagicLinkAuthenticatorConstants.STATE_PARAM_SUFFIX);
+            additionalAuthenticationParams.put(MagicLinkAuthenticatorConstants.STATE_PARAM, state);
+            AdditionalData additionalData = new AdditionalData();
+            additionalData.setAdditionalAuthenticationParams(additionalAuthenticationParams);
+            authenticatorData.setAdditionalData(additionalData);
         }
 
         return Optional.of(authenticatorData);

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorConstants.java
@@ -56,6 +56,8 @@ public abstract class MagicLinkAuthenticatorConstants {
     public static final String EXPIRYTIME = "expiry-time";
     public static final String IS_API_BASED_AUTHENTICATION_SUPPORTED = "isAPIBasedAuthenticationSupported";
     public static final String CALLBACK_URL = "callbackUrl";
+    public static final String STATE_PARAM_SUFFIX = "_state_param";
+    public static final String STATE_PARAM = "state";
 
     /**
      * Constants related to log management.


### PR DESCRIPTION
This PR sets a state param to the request for the client to be able to correlate the magic link coming to the app in API based authentication flow. The code is written in this manner as it is not possible to dynamically set params to the email template.

Related to https://github.com/wso2/product-is/issues/15684