### PR TITLE
Add username exist in request validation to prompt Identifier first prompt

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
@@ -114,7 +114,7 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
             LogoutFailedException {
 
         this.authenticationContext = context;
-        if (!isIdfInitiatedFromMagicLink()) {
+        if (!isIdfInitiatedFromMagicLink() || !isUsernameAvailableInRequest(request)) {
             return super.process(request, response, authenticationContext);
         }
         if (context.isLogoutRequest()) {
@@ -515,6 +515,11 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
                     MagicLinkAuthErrorConstants.ErrorMessages.EMPTY_USERNAME.getMessage());
         }
         return identifierFromRequest;
+    }
+
+    private boolean isUsernameAvailableInRequest(HttpServletRequest request) {
+
+        return StringUtils.isNotBlank(request.getParameter(USER_NAME));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
@@ -93,7 +93,7 @@ import static org.wso2.carbon.identity.application.authenticator.magiclink.Magic
         AbstractUserStoreManager.class, MagicLinkAuthContextCache.class, MagicLinkServiceDataHolder.class,
         ConfigurationFacade.class, FrameworkUtils.class, MultitenantUtils.class, UserCoreUtil.class,
         FrameworkServiceDataHolder.class, LoggerUtils.class })
-@PowerMockIgnore({ "javax.net.*", "javax.security.*", "javax.crypto.*", "javax.xml.*" })
+@PowerMockIgnore({ "javax.net.*", "javax.security.*", "javax.crypto.*", "javax.xml.*", "jdk.internal.reflect.*" })
 public class MagicLinkAuthenticatorTest {
 
     private static final String USER_STORE_DOMAIN = "PRIMARY";


### PR DESCRIPTION
A method to check for the existence of the username in the request is added with this PR. This method will be used along with the existing `isIdfInitiatedFromMagicLink()` method to show the IDF prompt.

Related issue:
- https://github.com/wso2/product-is/issues/18951