### PR TITLE
Extends authentication executor

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -36,7 +36,7 @@ import org.wso2.carbon.identity.event.handler.notification.NotificationConstants
 import org.wso2.carbon.identity.flow.execution.engine.Constants;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineClientException;
 import org.wso2.carbon.identity.flow.execution.engine.exception.FlowEngineException;
-import org.wso2.carbon.identity.flow.execution.engine.graph.Executor;
+import org.wso2.carbon.identity.flow.execution.engine.graph.AuthenticationExecutor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.user.core.common.User;
@@ -61,7 +61,7 @@ import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION
 /**
  * MagicLinkExecutor is responsible for handling the magic link flow.
  */
-public class MagicLinkExecutor implements Executor {
+public class MagicLinkExecutor extends AuthenticationExecutor {
 
     private static final Log LOG = LogFactory.getLog(MagicLinkExecutor.class);
     public static final String MLT = "mlt";
@@ -73,6 +73,12 @@ public class MagicLinkExecutor implements Executor {
     public String getName() {
 
         return "MagicLinkExecutor";
+    }
+
+    @Override
+    public String getAMRValue() {
+
+        return MagicLinkAuthenticatorConstants.AUTHENTICATOR_NAME;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.8.331</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.403</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.9.59</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.11.172</identity.inbound.auth.oauth.version>


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24768

This pull request updates the `MagicLinkExecutor` implementation to improve its integration with the authentication flow engine and ensures compatibility with the latest identity framework version. The most important changes are grouped by theme below:

**Authentication Flow Integration:**

* Changed `MagicLinkExecutor` to extend `AuthenticationExecutor` instead of implementing the generic `Executor` interface, aligning it with the authentication flow engine's conventions. [[1]](diffhunk://#diff-a30f16c8a26acdeef4ea12b9e9990decae14315c3c91ed9cd338875efd72262cL39-R39) [[2]](diffhunk://#diff-a30f16c8a26acdeef4ea12b9e9990decae14315c3c91ed9cd338875efd72262cL64-R64)
* Added the `getAMRValue()` method to `MagicLinkExecutor`, returning the authenticator name as the Authentication Method Reference (AMR) value, which is important for downstream authentication processing.

**Dependency Updates:**

* Updated the `carbon.identity.framework.version` in `pom.xml` from `7.8.331` to `7.8.403` to ensure compatibility with recent changes and improvements in the identity framework.