### PR TITLE
Improve MagicLinkExecutor to send state param instead of flowId

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
@@ -57,6 +58,8 @@ import static org.wso2.carbon.identity.application.authenticator.magiclink.execu
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.LogConstants.ActionIDs.SEND_MAGIC_LINK;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.LogConstants.MAGIC_LINK_AUTH_SERVICE;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.MAGIC_LINK_AUTH_CONTEXT_DATA;
+import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.MAGIC_LINK_STATE_VALUE;
+import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.STATE_PARAM;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.INVITED_USER_REGISTRATION;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.PASSWORD_RECOVERY;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
@@ -156,8 +159,16 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
 
         String expiryTime =
                 TimeUnit.SECONDS.toMinutes(getExpiryTime()) + " " + TimeUnit.MINUTES.name().toLowerCase();
-        magicToken = magicToken + "&" + "flowId=" + context.getContextIdentifier();
+        String state = UUID.randomUUID().toString();
+        context.getProperties().put(MAGIC_LINK_STATE_VALUE, state);
+        magicToken = magicToken + "&" + STATE_PARAM + "=" + state;
         triggerEvent(context, user, magicToken, expiryTime, context.getPortalUrl());
+        Map<String, String> additionalInfo = response.getAdditionalInfo();
+        if (additionalInfo == null) {
+            additionalInfo = new HashMap<>();
+        }
+        additionalInfo.put(STATE_PARAM, state);
+        response.setAdditionalInfo(additionalInfo);
         return userInputRequiredResponse(response, MLT);
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorConstants.java
@@ -28,6 +28,8 @@ public class MagicLinkExecutorConstants {
     }
 
     public static final String MAGIC_LINK_AUTH_CONTEXT_DATA = "magicLinkAuthContextData";
+    public static final String STATE_PARAM = "state";
+    public static final String MAGIC_LINK_STATE_VALUE = "magicLinkStateValue";
 
     /**
      * Constants related to log management.


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25583

This pull request introduces improvements to the magic link authentication flow by adding a unique state parameter to each generated magic link. This change helps enhance security and supports better tracking of authentication sessions. The most important changes are grouped below:

**Magic Link State Management:**

* Added generation of a unique state value using `UUID.randomUUID()` for each magic link and included it as a parameter in the magic link URL (`STATE_PARAM`). The state is also stored in the authentication context properties for later validation.
* Passed the generated state value in the response's `additionalInfo` map, allowing downstream components to access and verify the state during authentication.

**Constants Updates:**

* Introduced new constants `STATE_PARAM` and `MAGIC_LINK_STATE_VALUE` in `MagicLinkExecutorConstants.java` to standardize the usage of the state parameter throughout the codebase.
* Updated imports in `MagicLinkExecutor.java` to include these new constants for use in the magic link generation logic.

**Dependency Update:**

* Imported `java.util.UUID` in `MagicLinkExecutor.java` to support random state generation.