### PR TITLE
[bug-fix] Password Recovery Flow Breaks due to type conversion issue.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -187,15 +187,15 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
 
         MagicLinkExecutorContextData magicLinkExecContextData = getMagicLinkFromContext(context, response);
         if (magicLinkExecContextData == null) {
-            return userErrorResponse(response, "Invalid or expired magic link token.");
+            return userErrorResponse(response, "{{magic.link.error.message}}");
         }
 
         if (!isMagicTokenValid(magicLinkExecContextData)) {
-            return userErrorResponse(response, "Magic link token has expired.");
+            return userErrorResponse(response, "{{magic.link.error.message}}");
         }
 
         if (!magicToken.equals(magicLinkExecContextData.getMagicToken())) {
-            return userErrorResponse(response, "Invalid or expired magic link token.");
+            return userErrorResponse(response, "{{magic.link.error.message}}");
         }
 
         DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -373,19 +373,21 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
      */
     private static MagicLinkExecutorContextData getMagicLinkFromContext(FlowExecutionContext flowExecutionContext,
                                                                     ExecutorResponse response) {
+
         Object value = flowExecutionContext.getProperty(MAGIC_LINK_EXECUTOR_CONTEXT);
+        if (value == null) {
+            response.setResult(Constants.ExecutorStatus.STATUS_ERROR);
+            response.setErrorMessage("Magic Link is not generated.");
+            return null;
+        }
+
         ObjectMapper objectMapper = new ObjectMapper();
         HashMap<String, Object> contextMagicLink = objectMapper.convertValue(value,
                 new TypeReference<HashMap<String, Object>>() {
                 });
-        if (contextMagicLink == null) {
-            response.setResult(Constants.ExecutorStatus.STATUS_ERROR);
-            response.setErrorMessage("OTP is not generated.");
-            return null;
-        }
 
         Long createdTimestamp;
-        if (contextMagicLink.get(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP) instanceof Integer){
+        if (contextMagicLink.get(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP) instanceof Integer) {
             createdTimestamp =
                     ((Integer) contextMagicLink.get(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP))
                             .longValue();
@@ -393,7 +395,7 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
             createdTimestamp = (Long) contextMagicLink.get(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP);
         } else {
             response.setResult(Constants.ExecutorStatus.STATUS_ERROR);
-            response.setErrorMessage("Invalid OTP data.");
+            response.setErrorMessage("Invalid Magic Link.");
             return null;
         }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -154,7 +154,7 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
         magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.MAGIC_TOKEN, magicToken);
         magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP
                 ,System.currentTimeMillis());
-        magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.flowID,
+        magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.FLOW_ID,
                 context.getContextIdentifier());
 
         response.getContextProperties().put(MAGIC_LINK_EXECUTOR_CONTEXT,

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -149,23 +149,26 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
         attributes.put(EMAIL_ADDRESS_CLAIM, emailAddress);
         user.setAttributes(attributes);
 
-        HashMap<String, Object> magicLinkExecContextData = new HashMap<>();
-        String magicToken = TokenGenerator.generateToken(MagicLinkAuthenticatorConstants.TOKEN_LENGTH);
-        magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.MAGIC_TOKEN, magicToken);
-        magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP
-                ,System.currentTimeMillis());
-        magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.FLOW_ID,
-                context.getContextIdentifier());
-
-        response.getContextProperties().put(MAGIC_LINK_EXECUTOR_CONTEXT,
-                magicLinkExecContextData);
-
-        String expiryTime =
-                TimeUnit.SECONDS.toMinutes(getExpiryTime()) + " " + TimeUnit.MINUTES.name().toLowerCase();
         String state = UUID.randomUUID().toString();
-        context.getProperties().put(MAGIC_LINK_STATE_VALUE, state);
-        magicToken = magicToken + "&" + STATE_PARAM + "=" + state;
-        triggerEvent(context, user, magicToken, expiryTime, context.getPortalUrl());
+        if (StringUtils.isNotBlank(emailAddress)) {
+            HashMap<String, Object> magicLinkExecContextData = new HashMap<>();
+            String magicToken = TokenGenerator.generateToken(MagicLinkAuthenticatorConstants.TOKEN_LENGTH);
+            magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.MAGIC_TOKEN, magicToken);
+            magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP
+                    ,System.currentTimeMillis());
+            magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.FLOW_ID,
+                    context.getContextIdentifier());
+
+            response.getContextProperties().put(MAGIC_LINK_EXECUTOR_CONTEXT,
+                    magicLinkExecContextData);
+
+            String expiryTime =
+                    TimeUnit.SECONDS.toMinutes(getExpiryTime()) + " " + TimeUnit.MINUTES.name().toLowerCase();
+
+            context.getProperties().put(MAGIC_LINK_STATE_VALUE, state);
+            magicToken = magicToken + "&" + STATE_PARAM + "=" + state;
+            triggerEvent(context, user, magicToken, expiryTime, context.getPortalUrl());
+        }
         Map<String, String> additionalInfo = response.getAdditionalInfo();
         if (additionalInfo == null) {
             additionalInfo = new HashMap<>();

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.application.authenticator.magiclink.executor;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -26,7 +28,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.magiclink.TokenGenerator;
 import org.wso2.carbon.identity.application.authenticator.magiclink.internal.MagicLinkServiceDataHolder;
-import org.wso2.carbon.identity.application.authenticator.magiclink.model.MagicLinkAuthContextData;
+import org.wso2.carbon.identity.application.authenticator.magiclink.model.MagicLinkExecutorContextData;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -57,7 +59,7 @@ import static org.wso2.carbon.identity.application.authenticator.magiclink.Magic
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.LogConstants.ActionIDs.PROCESS_MAGIC_LINK;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.LogConstants.ActionIDs.SEND_MAGIC_LINK;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.LogConstants.MAGIC_LINK_AUTH_SERVICE;
-import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.MAGIC_LINK_AUTH_CONTEXT_DATA;
+import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.MAGIC_LINK_EXECUTOR_CONTEXT;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.MAGIC_LINK_STATE_VALUE;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.STATE_PARAM;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.INVITED_USER_REGISTRATION;
@@ -95,7 +97,7 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
         response.setContextProperty(contextProperties);
         try {
             validateRequiredData(context);
-            if (isInitiation(context)) {
+            if (isInitiation(context, response)) {
                 return initiateMagicLink(context, response);
             } else {
                 return processMagicLink(context, response);
@@ -147,15 +149,16 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
         attributes.put(EMAIL_ADDRESS_CLAIM, emailAddress);
         user.setAttributes(attributes);
 
-        MagicLinkAuthContextData magicLinkAuthContextData = new MagicLinkAuthContextData();
+        HashMap<String, Object> magicLinkExecContextData = new HashMap<>();
         String magicToken = TokenGenerator.generateToken(MagicLinkAuthenticatorConstants.TOKEN_LENGTH);
-        magicLinkAuthContextData.setMagicToken(magicToken);
-        magicLinkAuthContextData.setCreatedTimestamp(System.currentTimeMillis());
-        magicLinkAuthContextData.setUser(user);
-        magicLinkAuthContextData.setSessionDataKey(context.getContextIdentifier());
+        magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.MAGIC_TOKEN, magicToken);
+        magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP
+                ,System.currentTimeMillis());
+        magicLinkExecContextData.put(MagicLinkExecutorConstants.MagicLinkData.flowID,
+                context.getContextIdentifier());
 
-        response.getContextProperties().put(MAGIC_LINK_AUTH_CONTEXT_DATA,
-                magicLinkAuthContextData);
+        response.getContextProperties().put(MAGIC_LINK_EXECUTOR_CONTEXT,
+                magicLinkExecContextData);
 
         String expiryTime =
                 TimeUnit.SECONDS.toMinutes(getExpiryTime()) + " " + TimeUnit.MINUTES.name().toLowerCase();
@@ -179,36 +182,30 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
             return userErrorResponse(response, "Magic Link token is required for verification.");
         }
 
-        MagicLinkAuthContextData magicLinkAuthContextData = (MagicLinkAuthContextData)
-                context.getProperty(MAGIC_LINK_AUTH_CONTEXT_DATA);
-        if (magicLinkAuthContextData == null) {
+        MagicLinkExecutorContextData magicLinkExecContextData = getMagicLinkFromContext(context, response);
+        if (magicLinkExecContextData == null) {
             return userErrorResponse(response, "Invalid or expired magic link token.");
         }
 
-        if (!isMagicTokenValid(magicLinkAuthContextData)) {
+        if (!isMagicTokenValid(magicLinkExecContextData)) {
             return userErrorResponse(response, "Magic link token has expired.");
         }
 
-        User user = magicLinkAuthContextData.getUser();
-        if (user == null || user.getUsername() == null) {
-            return userErrorResponse(response, "User information is missing in the magic link token.");
-        }
-
-        if (!user.getUsername().equals(context.getFlowUser().getUsername())) {
-            return userErrorResponse(response, "Username mismatch in the magic link token.");
+        if (!magicToken.equals(magicLinkExecContextData.getMagicToken())) {
+            return userErrorResponse(response, "Invalid or expired magic link token.");
         }
 
         DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(MAGIC_LINK_AUTH_SERVICE, PROCESS_MAGIC_LINK);
             diagnosticLogBuilder.logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
-                    .inputParam("user store domain", user.getUserStoreDomain())
+                    .inputParam("user store domain", context.getFlowUser().getUserStoreDomain())
                     .inputParam(LogConstants.InputKeys.USER, LoggerUtils.isLogMaskingEnable ?
-                            LoggerUtils.getMaskedContent(user.getUsername()) : user.getUsername())
-                    .inputParam(LogConstants.InputKeys.USER_ID, user.getUserID());
+                            LoggerUtils.getMaskedContent(context.getFlowUser().getUsername()) :
+                            context.getFlowUser().getUsername());
         }
 
-        context.getProperties().remove(MAGIC_LINK_AUTH_CONTEXT_DATA);
+        context.getProperties().remove(MAGIC_LINK_EXECUTOR_CONTEXT);
         response.setResult(Constants.ExecutorStatus.STATUS_COMPLETE);
         return response;
     }
@@ -268,10 +265,10 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
         }
     }
 
-    private boolean isInitiation(FlowExecutionContext context) {
+    private boolean isInitiation(FlowExecutionContext context, ExecutorResponse response) {
 
         return context.getUserInputData().get(MLT) == null &&
-                context.getProperty(MAGIC_LINK_AUTH_CONTEXT_DATA) == null;
+                getMagicLinkFromContext(context, response) == null;
     }
 
     private void validateRequiredData(FlowExecutionContext context) throws FlowEngineException {
@@ -308,14 +305,14 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
     /**
      * Validate the magic token.
      *
-     * @param magicLinkAuthContextData The magic link authentication context data.
+     * @param magicLinkExecContextData The magic link authentication context data.
      * @return true if the token is valid, false otherwise.
      */
-    private boolean isMagicTokenValid(MagicLinkAuthContextData magicLinkAuthContextData) {
+    private boolean isMagicTokenValid(MagicLinkExecutorContextData magicLinkExecContextData) {
 
-        if (magicLinkAuthContextData != null) {
+        if (magicLinkExecContextData != null) {
             long currentTimestamp = System.currentTimeMillis();
-            long createdTimestamp = magicLinkAuthContextData.getCreatedTimestamp();
+            long createdTimestamp = magicLinkExecContextData.getCreatedTimestamp();
             long tokenValidityPeriod = TimeUnit.SECONDS.toMillis(getExpiryTime());
             return currentTimestamp - createdTimestamp < tokenValidityPeriod;
         }
@@ -357,5 +354,46 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
         } else if (PASSWORD_RECOVERY.getType().equals(flowType)) {
             properties.put(MagicLinkAuthenticatorConstants.TEMPLATE_TYPE, MAGIC_LINK_PASSWORD_RECOVERY_TEMPLATE);
         }
+    }
+
+    /**
+     * Retrieve the MagicLinkExecutorContextData from the FlowExecutionContext.
+     *
+     * @param flowExecutionContext The flow execution context.
+     * @param response             The executor response to set error messages if any.
+     * @return The MagicLinkExecutorContextData or null if not found or invalid.
+     */
+    private static MagicLinkExecutorContextData getMagicLinkFromContext(FlowExecutionContext flowExecutionContext,
+                                                                    ExecutorResponse response) {
+        Object value = flowExecutionContext.getProperty(MAGIC_LINK_EXECUTOR_CONTEXT);
+        ObjectMapper objectMapper = new ObjectMapper();
+        HashMap<String, Object> contextMagicLink = objectMapper.convertValue(value,
+                new TypeReference<HashMap<String, Object>>() {
+                });
+        if (contextMagicLink == null) {
+            response.setResult(Constants.ExecutorStatus.STATUS_ERROR);
+            response.setErrorMessage("OTP is not generated.");
+            return null;
+        }
+
+        Long createdTimestamp;
+        if (contextMagicLink.get(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP) instanceof Integer){
+            createdTimestamp =
+                    ((Integer) contextMagicLink.get(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP))
+                            .longValue();
+        } else if (contextMagicLink.get(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP) instanceof Long) {
+            createdTimestamp = (Long) contextMagicLink.get(MagicLinkExecutorConstants.MagicLinkData.CREATED_TIMESTAMP);
+        } else {
+            response.setResult(Constants.ExecutorStatus.STATUS_ERROR);
+            response.setErrorMessage("Invalid OTP data.");
+            return null;
+        }
+
+        MagicLinkExecutorContextData magicLinkExecContextData = new MagicLinkExecutorContextData();
+        magicLinkExecContextData.setMagicToken(
+                (String) contextMagicLink.get(MagicLinkExecutorConstants.MagicLinkData.MAGIC_TOKEN));
+        magicLinkExecContextData.setCreatedTimestamp(createdTimestamp);
+        magicLinkExecContextData.setFlowID(flowExecutionContext.getContextIdentifier());
+        return magicLinkExecContextData;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorConstants.java
@@ -50,7 +50,7 @@ public class MagicLinkExecutorConstants {
 
     public static class MagicLinkData {
 
-        public static final String flowID  = "flowID";
+        public static final String FLOW_ID = "flowID";
         public static final String MAGIC_TOKEN= "magicToken";
         public static final String CREATED_TIMESTAMP = "createdTimestamp";
 

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorConstants.java
@@ -51,7 +51,7 @@ public class MagicLinkExecutorConstants {
     public static class MagicLinkData {
 
         public static final String FLOW_ID = "flowID";
-        public static final String MAGIC_TOKEN= "magicToken";
+        public static final String MAGIC_TOKEN = "magicToken";
         public static final String CREATED_TIMESTAMP = "createdTimestamp";
 
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorConstants.java
@@ -27,7 +27,7 @@ public class MagicLinkExecutorConstants {
 
     }
 
-    public static final String MAGIC_LINK_AUTH_CONTEXT_DATA = "magicLinkAuthContextData";
+    public static final String MAGIC_LINK_EXECUTOR_CONTEXT = "magicLinkExecutorContextData";
     public static final String STATE_PARAM = "state";
     public static final String MAGIC_LINK_STATE_VALUE = "magicLinkStateValue";
 
@@ -46,5 +46,13 @@ public class MagicLinkExecutorConstants {
             public static final String SEND_MAGIC_LINK = "send-magiclink-token";
             public static final String PROCESS_MAGIC_LINK = "process-magiclink-token";
         }
+    }
+
+    public static class MagicLinkData {
+
+        public static final String flowID  = "flowID";
+        public static final String MAGIC_TOKEN= "magicToken";
+        public static final String CREATED_TIMESTAMP = "createdTimestamp";
+
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/model/MagicLinkExecutorContextData.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/model/MagicLinkExecutorContextData.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.magiclink.model;
+
+import java.io.Serializable;
+
+/**
+ * Magic Link flow context data.
+ */
+public class MagicLinkExecutorContextData implements Serializable {
+
+    private String flowID;
+    private String magicToken;
+    private long createdTimestamp;
+
+    public String getFlowID() {
+
+        return flowID;
+    }
+
+    public void setFlowID(String flowID) {
+
+        this.flowID = flowID;
+    }
+
+    public String getMagicToken() {
+
+        return magicToken;
+    }
+
+    public void setMagicToken(String magicToken) {
+
+        this.magicToken = magicToken;
+    }
+
+    public long getCreatedTimestamp() {
+
+        return createdTimestamp;
+    }
+
+    public void setCreatedTimestamp(long createdTimestamp) {
+
+        this.createdTimestamp = createdTimestamp;
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/model/MagicLinkExecutorContextData.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/model/MagicLinkExecutorContextData.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 /**
  * Magic Link flow context data.
  */
-public class MagicLinkExecutorContextData implements Serializable {
+public class MagicLinkExecutorContextData {
 
     private String flowID;
     private String magicToken;

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
@@ -197,7 +197,7 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
         prepareVerificationContext(true, -999999L);
         ExecutorResponse response = executor.execute(context);
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_ERROR);
-        assertTrue(response.getErrorMessage().contains("expired"));
+        assertTrue(response.getErrorMessage().contains("magic.link.error.message"));
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
@@ -263,7 +263,7 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
         assertTrue(response.getAdditionalInfo().containsKey(STATE_PARAM));
 
         verify(eventService, never()).handleEvent(any(Event.class));
-        assertNull(response.getContextProperties().get(MAGIC_LINK_AUTH_CONTEXT_DATA));
+        assertNull(response.getContextProperties().get(MAGIC_LINK_EXECUTOR_CONTEXT));
     }
 
     @Test
@@ -285,7 +285,7 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
         assertTrue(response.getAdditionalInfo().containsKey(STATE_PARAM));
 
         verify(eventService).handleEvent(any(Event.class));
-        assertNotNull(response.getContextProperties().get(MAGIC_LINK_AUTH_CONTEXT_DATA));
+        assertNotNull(response.getContextProperties().get(MAGIC_LINK_EXECUTOR_CONTEXT));
     }
 
     private void prepareInitiationContext() {

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
@@ -30,7 +30,7 @@ import org.wso2.carbon.identity.application.authentication.framework.config.mode
 import org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.magiclink.TokenGenerator;
 import org.wso2.carbon.identity.application.authenticator.magiclink.internal.MagicLinkServiceDataHolder;
-import org.wso2.carbon.identity.application.authenticator.magiclink.model.MagicLinkAuthContextData;
+import org.wso2.carbon.identity.application.authenticator.magiclink.model.MagicLinkExecutorContextData;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
@@ -61,7 +61,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutor.MAGIC_LINK_PASSWORD_RECOVERY_TEMPLATE;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutor.MAGIC_LINK_SIGN_UP_TEMPLATE;
-import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.MAGIC_LINK_AUTH_CONTEXT_DATA;
+import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.MAGIC_LINK_EXECUTOR_CONTEXT;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.PASSWORD_RECOVERY;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
 
@@ -172,7 +172,7 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
     @Test
     public void testExecuteProcessesMagicLinkSuccess() throws Exception {
 
-        prepareVerificationContext(true, TEST_USERNAME);
+        prepareVerificationContext(true);
         ExecutorResponse response = executor.execute(context);
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_COMPLETE);
     }
@@ -180,7 +180,7 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
     @Test
     public void testExecuteFailsWithMissingToken() throws Exception {
 
-        prepareVerificationContext(false, TEST_USERNAME);
+        prepareVerificationContext(false);
         ExecutorResponse response = executor.execute(context);
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_ERROR);
         assertNotNull(response.getErrorMessage());
@@ -189,19 +189,10 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
     @Test
     public void testExecuteFailsWithExpiredToken() throws Exception {
 
-        prepareVerificationContext(true, TEST_USERNAME, -999999L);
+        prepareVerificationContext(true, -999999L);
         ExecutorResponse response = executor.execute(context);
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_ERROR);
         assertTrue(response.getErrorMessage().contains("expired"));
-    }
-
-    @Test
-    public void testExecuteFailsWithUserMismatch() throws Exception {
-
-        prepareVerificationContext(true, "differentUser");
-        ExecutorResponse response = executor.execute(context);
-        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_ERROR);
-        assertTrue(response.getErrorMessage().contains("Username mismatch"));
     }
 
     @Test
@@ -259,12 +250,12 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
         when(context.getUserInputData()).thenReturn(new HashMap<>());
     }
 
-    private void prepareVerificationContext(boolean includeToken, String contextUsername) {
+    private void prepareVerificationContext(boolean includeToken) {
 
-        prepareVerificationContext(includeToken, contextUsername, System.currentTimeMillis());
+        prepareVerificationContext(includeToken, System.currentTimeMillis());
     }
 
-    private void prepareVerificationContext(boolean includeToken, String contextUsername, long timestamp) {
+    private void prepareVerificationContext(boolean includeToken, long timestamp) {
 
         when(flowUser.getUsername()).thenReturn(TEST_USERNAME);
         when(flowUser.getClaim(EMAIL_ADDRESS_CLAIM)).thenReturn(TEST_EMAIL);
@@ -275,24 +266,15 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
         }
         when(context.getUserInputData()).thenReturn(input);
 
-        User user = new User();
-        user.setUsername(contextUsername);
-        user.setTenantDomain(TEST_TENANT);
-        Map<String, String> attrs = new HashMap<>();
-        attrs.put(USERNAME_CLAIM, contextUsername);
-        attrs.put(EMAIL_ADDRESS_CLAIM, TEST_EMAIL);
-        user.setAttributes(attrs);
-
-        MagicLinkAuthContextData data = new MagicLinkAuthContextData();
-        data.setUser(user);
+        MagicLinkExecutorContextData data = new MagicLinkExecutorContextData();
         data.setMagicToken(TEST_TOKEN);
         data.setCreatedTimestamp(System.currentTimeMillis() + timestamp);
-        data.setSessionDataKey(TEST_CONTEXT_ID);
+        data.setFlowID(TEST_CONTEXT_ID);
 
         Map<String, Object> props = new HashMap<>();
-        props.put(MAGIC_LINK_AUTH_CONTEXT_DATA, data);
+        props.put(MAGIC_LINK_EXECUTOR_CONTEXT, data);
 
-        when(context.getProperty(MAGIC_LINK_AUTH_CONTEXT_DATA)).thenReturn(data);
+        when(context.getProperty(MAGIC_LINK_EXECUTOR_CONTEXT)).thenReturn(data);
         when(context.getProperties()).thenReturn(props);
     }
 }


### PR DESCRIPTION
### Purpose
In the password recovery flow, the process breaks upon clicking the magic link. Instead of prompting the user to retry or showing a proper error message, the flow is interrupted. This happens when the magic link data is retrieved from the database instead from in-memory while type conversion due to deserialisation issue in nested objects.

### Related issues
- https://github.com/wso2/product-is/issues/25673

### Related PRs
- https://github.com/wso2-extensions/identity-auth-otp-commons/pull/26
