### PR TITLE
Send flowId in magic link 

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -58,8 +58,6 @@ import static org.wso2.carbon.identity.application.authenticator.magiclink.execu
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.LogConstants.ActionIDs.SEND_MAGIC_LINK;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.LogConstants.MAGIC_LINK_AUTH_SERVICE;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.MAGIC_LINK_AUTH_CONTEXT_DATA;
-import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.MAGIC_LINK_STATE_VALUE;
-import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.STATE_PARAM;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.INVITED_USER_REGISTRATION;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.PASSWORD_RECOVERY;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
@@ -161,17 +159,9 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
 
             String expiryTime =
                     TimeUnit.SECONDS.toMinutes(getExpiryTime()) + " " + TimeUnit.MINUTES.name().toLowerCase();
-
-            context.getProperties().put(MAGIC_LINK_STATE_VALUE, state);
-            magicToken = magicToken + "&" + STATE_PARAM + "=" + state;
+            magicToken = magicToken + "&" + "flowId=" + context.getContextIdentifier();
             triggerEvent(context, user, magicToken, expiryTime, context.getPortalUrl());
         }
-        Map<String, String> additionalInfo = response.getAdditionalInfo();
-        if (additionalInfo == null) {
-            additionalInfo = new HashMap<>();
-        }
-        additionalInfo.put(STATE_PARAM, state);
-        response.setAdditionalInfo(additionalInfo);
         return userInputRequiredResponse(response, MLT);
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorConstants.java
@@ -28,8 +28,6 @@ public class MagicLinkExecutorConstants {
     }
 
     public static final String MAGIC_LINK_AUTH_CONTEXT_DATA = "magicLinkAuthContextData";
-    public static final String STATE_PARAM = "state";
-    public static final String MAGIC_LINK_STATE_VALUE = "magicLinkStateValue";
 
     /**
      * Constants related to log management.

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
@@ -63,7 +63,6 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutor.MAGIC_LINK_PASSWORD_RECOVERY_TEMPLATE;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutor.MAGIC_LINK_SIGN_UP_TEMPLATE;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.MAGIC_LINK_AUTH_CONTEXT_DATA;
-import static org.wso2.carbon.identity.application.authenticator.magiclink.executor.MagicLinkExecutorConstants.STATE_PARAM;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.PASSWORD_RECOVERY;
 import static org.wso2.carbon.identity.flow.mgt.Constants.FlowTypes.REGISTRATION;
 
@@ -161,8 +160,6 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED);
         assertTrue(response.getRequiredData().contains(MagicLinkExecutor.MLT));
         assertNotNull(response.getAdditionalInfo());
-        assertTrue(response.getAdditionalInfo().containsKey(STATE_PARAM));
-        assertNotNull(response.getAdditionalInfo().get(STATE_PARAM));
     }
 
     @Test
@@ -268,8 +265,6 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
         ExecutorResponse response = executor.execute(context);
 
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED);
-        assertNotNull(response.getAdditionalInfo());
-        assertTrue(response.getAdditionalInfo().containsKey(STATE_PARAM));
 
         verify(eventService, never()).handleEvent(any(Event.class));
         assertNull(response.getContextProperties().get(MAGIC_LINK_AUTH_CONTEXT_DATA));
@@ -290,8 +285,6 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
         ExecutorResponse response = executor.execute(context);
 
         assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED);
-        assertNotNull(response.getAdditionalInfo());
-        assertTrue(response.getAdditionalInfo().containsKey(STATE_PARAM));
 
         verify(eventService).handleEvent(any(Event.class));
         assertNotNull(response.getContextProperties().get(MAGIC_LINK_AUTH_CONTEXT_DATA));


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25694

This pull request refactors the handling of the magic link state parameter in the Magic Link Authenticator. The main change is the removal of the `state` parameter from the magic link generation and response, replacing it with the use of `flowId` from the context. Related constants and test assertions have also been updated to reflect this change.

**Magic Link state parameter removal and flowId usage:**

* Removed usage of `MAGIC_LINK_STATE_VALUE` and `STATE_PARAM` constants in `MagicLinkExecutor.java`, and updated the magic link to append `flowId` from the context identifier instead of `state`. [[1]](diffhunk://#diff-a30f16c8a26acdeef4ea12b9e9990decae14315c3c91ed9cd338875efd72262cL61-L62) [[2]](diffhunk://#diff-a30f16c8a26acdeef4ea12b9e9990decae14315c3c91ed9cd338875efd72262cL164-L174)
* Deleted the `STATE_PARAM` and `MAGIC_LINK_STATE_VALUE` constants from `MagicLinkExecutorConstants.java`.

**Test updates:**

* Removed imports and assertions related to `STATE_PARAM` in `MagicLinkExecutorTest.java` to align with the new logic that no longer uses the `state` parameter. [[1]](diffhunk://#diff-9b4f7522e09dcc4520c0e6826aae9685d42d7fab9da71444829539462e78e9b1L66) [[2]](diffhunk://#diff-9b4f7522e09dcc4520c0e6826aae9685d42d7fab9da71444829539462e78e9b1L164-L165) [[3]](diffhunk://#diff-9b4f7522e09dcc4520c0e6826aae9685d42d7fab9da71444829539462e78e9b1L271-L272) [[4]](diffhunk://#diff-9b4f7522e09dcc4520c0e6826aae9685d42d7fab9da71444829539462e78e9b1L293-L294)