### PR TITLE
Streamline flow handling and enhance user account checks

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -121,7 +121,7 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
         String emailAddress = (String) context.getFlowUser().getClaim(EMAIL_ADDRESS_CLAIM);
 
         if (!context.getFlowUser().isCredentialsManagedLocally() || context.getFlowUser().isAccountLocked() ||
-        context.getFlowUser().isAccountDisabled()) {
+                context.getFlowUser().isAccountDisabled()) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Magic link is not triggered for the user: " + (LoggerUtils.isLogMaskingEnable ?
                         LoggerUtils.getMaskedContent(username) : username) + ". User account is either locked, " +

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
@@ -132,24 +132,68 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
     public void testGetInitiationData() {
 
         List<String> data = executor.getInitiationData();
-        assertEquals(data.size(), 2);
-        assertTrue(data.contains(USERNAME_CLAIM));
+        assertEquals(data.size(), 1);
         assertTrue(data.contains(EMAIL_ADDRESS_CLAIM));
     }
 
-    @Test(expectedExceptions = FlowEngineClientException.class)
-    public void testExecuteThrowsWhenUsernameMissing() throws FlowEngineException {
-
-        when(flowUser.getUsername()).thenReturn(null);
-        executor.execute(context);
-    }
-
-    @Test(expectedExceptions = FlowEngineClientException.class)
-    public void testExecuteThrowsWhenEmailMissing() throws FlowEngineException {
+    @Test
+    public void testExecuteWithNonLocallyManagedCredentials() throws Exception {
 
         when(flowUser.getUsername()).thenReturn(TEST_USERNAME);
-        when(flowUser.getClaim(EMAIL_ADDRESS_CLAIM)).thenReturn(null);
-        executor.execute(context);
+        when(flowUser.getClaim(EMAIL_ADDRESS_CLAIM)).thenReturn(TEST_EMAIL);
+        when(flowUser.isCredentialsManagedLocally()).thenReturn(false);
+        when(context.getTenantDomain()).thenReturn(TEST_TENANT);
+        when(context.getContextIdentifier()).thenReturn(TEST_CONTEXT_ID);
+        when(context.getPortalUrl()).thenReturn("https://portal");
+        when(context.getFlowType()).thenReturn("signup");
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getProperties()).thenReturn(new HashMap<>());
+
+        ExecutorResponse response = executor.execute(context);
+        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED);
+        assertTrue(response.getRequiredData().contains(MagicLinkExecutor.MLT));
+        verify(eventService, never()).handleEvent(any(Event.class));
+    }
+
+    @Test
+    public void testExecuteWithLockedAccount() throws Exception {
+
+        when(flowUser.getUsername()).thenReturn(TEST_USERNAME);
+        when(flowUser.getClaim(EMAIL_ADDRESS_CLAIM)).thenReturn(TEST_EMAIL);
+        when(flowUser.isCredentialsManagedLocally()).thenReturn(true);
+        when(flowUser.isAccountLocked()).thenReturn(true);
+        when(context.getTenantDomain()).thenReturn(TEST_TENANT);
+        when(context.getContextIdentifier()).thenReturn(TEST_CONTEXT_ID);
+        when(context.getPortalUrl()).thenReturn("https://portal");
+        when(context.getFlowType()).thenReturn("signup");
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getProperties()).thenReturn(new HashMap<>());
+
+        ExecutorResponse response = executor.execute(context);
+        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED);
+        assertTrue(response.getRequiredData().contains(MagicLinkExecutor.MLT));
+        verify(eventService, never()).handleEvent(any(Event.class));
+    }
+
+    @Test
+    public void testExecuteWithDisabledAccount() throws Exception {
+
+        when(flowUser.getUsername()).thenReturn(TEST_USERNAME);
+        when(flowUser.getClaim(EMAIL_ADDRESS_CLAIM)).thenReturn(TEST_EMAIL);
+        when(flowUser.isCredentialsManagedLocally()).thenReturn(true);
+        when(flowUser.isAccountLocked()).thenReturn(false);
+        when(flowUser.isAccountDisabled()).thenReturn(true);
+        when(context.getTenantDomain()).thenReturn(TEST_TENANT);
+        when(context.getContextIdentifier()).thenReturn(TEST_CONTEXT_ID);
+        when(context.getPortalUrl()).thenReturn("https://portal");
+        when(context.getFlowType()).thenReturn("signup");
+        when(context.getUserInputData()).thenReturn(new HashMap<>());
+        when(context.getProperties()).thenReturn(new HashMap<>());
+
+        ExecutorResponse response = executor.execute(context);
+        assertEquals(response.getResult(), Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED);
+        assertTrue(response.getRequiredData().contains(MagicLinkExecutor.MLT));
+        verify(eventService, never()).handleEvent(any(Event.class));
     }
 
     @Test
@@ -245,6 +289,9 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
 
         when(flowUser.getUsername()).thenReturn(TEST_USERNAME);
         when(flowUser.getClaim(EMAIL_ADDRESS_CLAIM)).thenReturn(null);
+        when(flowUser.isCredentialsManagedLocally()).thenReturn(true);
+        when(flowUser.isAccountLocked()).thenReturn(false);
+        when(flowUser.isAccountDisabled()).thenReturn(false);
         when(context.getTenantDomain()).thenReturn(TEST_TENANT);
         when(context.getContextIdentifier()).thenReturn(TEST_CONTEXT_ID);
         when(context.getPortalUrl()).thenReturn("https://portal");
@@ -265,6 +312,9 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
 
         when(flowUser.getUsername()).thenReturn(TEST_USERNAME);
         when(flowUser.getClaim(EMAIL_ADDRESS_CLAIM)).thenReturn(TEST_EMAIL);
+        when(flowUser.isCredentialsManagedLocally()).thenReturn(true);
+        when(flowUser.isAccountLocked()).thenReturn(false);
+        when(flowUser.isAccountDisabled()).thenReturn(false);
         when(context.getTenantDomain()).thenReturn(TEST_TENANT);
         when(context.getContextIdentifier()).thenReturn(TEST_CONTEXT_ID);
         when(context.getPortalUrl()).thenReturn("https://portal");
@@ -284,6 +334,9 @@ public class MagicLinkExecutorTest extends PowerMockTestCase {
 
         when(flowUser.getUsername()).thenReturn(TEST_USERNAME);
         when(flowUser.getClaim(EMAIL_ADDRESS_CLAIM)).thenReturn(TEST_EMAIL);
+        when(flowUser.isCredentialsManagedLocally()).thenReturn(true);
+        when(flowUser.isAccountLocked()).thenReturn(false);
+        when(flowUser.isAccountDisabled()).thenReturn(false);
         when(context.getTenantDomain()).thenReturn(TEST_TENANT);
         when(context.getContextIdentifier()).thenReturn(TEST_CONTEXT_ID);
         when(context.getPortalUrl()).thenReturn("https://portal");

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.8.403</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.499</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.9.59</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.11.172</identity.inbound.auth.oauth.version>


### PR DESCRIPTION
### Issue 

https://github.com/wso2/product-is/issues/25636

This pull request refactors the `MagicLinkExecutor` to simplify error handling, improve user eligibility checks for magic link initiation, and updates a framework dependency. The main changes include removing redundant validation and exception handling, adding stricter checks before sending a magic link, and updating the project to use a newer version of the Carbon Identity Framework.

### Logic and Validation Improvements

* Removed the `validateRequiredData` method and its invocation, along with the surrounding exception handling in the `execute` method, simplifying the flow and reducing unnecessary error wrapping. [[1]](diffhunk://#diff-a30f16c8a26acdeef4ea12b9e9990decae14315c3c91ed9cd338875efd72262cL97-L127) [[2]](diffhunk://#diff-a30f16c8a26acdeef4ea12b9e9990decae14315c3c91ed9cd338875efd72262cL267-L281)
* Updated the initiation logic to check if the user's credentials are managed locally, or if the account is locked or disabled, before proceeding with magic link initiation. If any of these conditions are true, the flow now returns early and logs the reason.

### Dependency Updates

* Updated the `carbon.identity.framework.version` dependency in `pom.xml` from `7.8.403` to `7.8.499`, ensuring the project uses the latest compatible framework version.

### Minor Adjustments

* Removed the addition of `USERNAME_CLAIM` from the initiation data, so only `EMAIL_ADDRESS_CLAIM` is required for initiation.