### PR TITLE
Update error codes to use BAS prefix

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/util/MagicLinkAuthErrorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/util/MagicLinkAuthErrorConstants.java
@@ -33,13 +33,13 @@ public class MagicLinkAuthErrorConstants {
         EMPTY_USERNAME("BAS-60002", "Username is empty."),
 
         // IO related Error codes.
-        SYSTEM_ERROR_WHILE_AUTHENTICATING("65001", "System error while authenticating"),
-        ERROR_CODE_ERROR_REDIRECTING_TO_ERROR_PAGE("65014",
+        SYSTEM_ERROR_WHILE_AUTHENTICATING("BAS-65001", "System error while authenticating"),
+        ERROR_CODE_ERROR_REDIRECTING_TO_ERROR_PAGE("BAS-65014",
                 "Error occurred while redirecting to the error page"),
 
         //Account locked error code.
-        ERROR_USER_ACCOUNT_LOCKED("65002", "Account is locked for the user: %s"),
-        ERROR_GETTING_ACCOUNT_LOCKED_STATE("65018", "Error occurred while checking the " +
+        ERROR_USER_ACCOUNT_LOCKED("BAS-65002", "Account is locked for the user: %s"),
+        ERROR_GETTING_ACCOUNT_LOCKED_STATE("BAS-65018", "Error occurred while checking the " +
                 "account locked state for the user: %s");
 
 


### PR DESCRIPTION
### Purpose
This PR updates the error code format in the `ErrorMessages` enum within the `MagicLinkAuthErrorConstants.java` file to use a consistent prefix for all error codes. 

### Related PRs
- https://github.com/wso2-extensions/identity-local-auth-magiclink/pull/72