### PR TITLE
Add OTFI generation to MagicLinkExecutor for unique flow IDs

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.OTFI;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.EMAIL_ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.magiclink.MagicLinkAuthenticatorConstants.DEFAULT_EXPIRY_TIME;
@@ -152,7 +153,16 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
 
             String expiryTime =
                     TimeUnit.SECONDS.toMinutes(getExpiryTime()) + " " + TimeUnit.MINUTES.name().toLowerCase();
-            magicToken = magicToken + "&" + "flowId=" + context.getContextIdentifier();
+
+            String otfi = UUID.randomUUID().toString();
+            // Make sure the generated OTFI is different from the current flow ID.
+            while (otfi.equals(context.getContextIdentifier())){
+                otfi = UUID.randomUUID().toString();
+            }
+            Map<String, Object> otfiProperties = new HashMap<>();
+            otfiProperties.put(OTFI, otfi);
+            context.addProperties(otfiProperties);
+            magicToken = magicToken + "&" + "flowId=" + otfi;
             triggerEvent(context, user, magicToken, expiryTime, context.getPortalUrl());
         }
         return userInputRequiredResponse(response, MLT);

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.8.520</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.521</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.9.59</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.11.172</identity.inbound.auth.oauth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.8.489</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.520</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.9.59</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.11.172</identity.inbound.auth.oauth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.wso2.carbon.identity.local.auth.magiclink</groupId>
     <artifactId>identity-local-auth-magiclink</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.44-SNAPSHOT</version>
+    <version>1.1.43</version>
     <name>WSO2 Carbon - MagicLink Authenticator</name>
     <scm>
         <url>https://github.com/wso2-extensions/identity-local-auth-magiclink.git</url>
@@ -299,7 +299,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.8.499</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.519</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.9.59</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.11.172</identity.inbound.auth.oauth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.wso2.carbon.identity.local.auth.magiclink</groupId>
     <artifactId>identity-local-auth-magiclink</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.43</version>
+    <version>1.1.44-SNAPSHOT</version>
     <name>WSO2 Carbon - MagicLink Authenticator</name>
     <scm>
         <url>https://github.com/wso2-extensions/identity-local-auth-magiclink.git</url>
@@ -299,7 +299,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.8.519</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.489</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.9.59</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.11.172</identity.inbound.auth.oauth.version>


### PR DESCRIPTION
**Related Issues**

- https://github.com/wso2/product-is/issues/25779

This pull request introduces an update to the magic link authentication flow to improve security and uniqueness of flow identifiers. The main change is the generation of a new, random OTFI (One-Time Flow Identifier) for each magic link, ensuring it does not collide with the current flow ID.

**Magic link flow improvements:**

* Added generation of a random OTFI using `UUID.randomUUID()`, with a check to ensure it does not match the current flow ID. The OTFI is then used as the flow identifier in the magic link instead of the context's identifier.
* Stored the newly generated OTFI in the context's properties map for use in subsequent authentication steps.
* Imported the `OTFI` constant from the flow execution engine for use as the property key in the context.