### PR TITLE
Use context-tenant-based username preprocessing in Magic Link Authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
@@ -554,7 +554,7 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
 
         String username = validateIdentifierFromRequest(request, context);
         validateEmailUsername(username, context);
-        username = FrameworkUtils.preprocessUsername(username, context);
+        username = FrameworkUtils.preprocessUsernameWithContextTenantDomain(username, context);
         User user = new User();
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         String tenantDomain = MultitenantUtils.getTenantDomain(username);

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.8.521</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.550</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.9.59</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.11.172</identity.inbound.auth.oauth.version>


### PR DESCRIPTION
### Purpose
Update the Magic Link Authenticator to use the newly introduced username preprocessing method that relies on the context tenant domain. This ensures consistent username handling with the context-aware logic used across components.

### Goals
* Replace the existing use of `FrameworkUtils.preprocessUsername()` with the new context-based variant.
* Maintain consistent and reliable username preprocessing behavior.

### Approach
* Updated the call in `MagicLinkAuthenticator` to use `FrameworkUtils.preprocessUsernameWithContextTenantDomain()`.
* No functional changes other than switching to the context-tenant-based preprocessing method.

### Related PRs
  - https://github.com/wso2/carbon-identity-framework/pull/7496