### PR TITLE
Update MagicLinkAuthenticator to support shared user direct login to sub-organizations.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
@@ -417,6 +417,7 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
         properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUsername());
         properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
         properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
+        properties.put(IdentityEventConstants.EventProperty.APPLICATION_DOMAIN, context.getTenantDomain());
         properties.put(MagicLinkAuthenticatorConstants.MAGIC_TOKEN, magicToken);
         properties.put(MagicLinkAuthenticatorConstants.TEMPLATE_TYPE, MagicLinkAuthenticatorConstants.EVENT_NAME);
         properties.put(IdentityEventConstants.EventProperty.APPLICATION_NAME, context.getServiceProviderName());
@@ -554,7 +555,7 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
 
         String username = validateIdentifierFromRequest(request, context);
         validateEmailUsername(username, context);
-        username = FrameworkUtils.preprocessUsernameWithContextTenantDomain(username, context);
+        username = FrameworkUtils.preprocessUsernameWithUserResidentTenantDomain(username, context);
         User user = new User();
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         String tenantDomain = MultitenantUtils.getTenantDomain(username);

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.10.84</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.74</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.9.59</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.11.172</identity.inbound.auth.oauth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <identity.application.authenticator.magiclink.exp.pkg.version>${project.version}
         </identity.application.authenticator.magiclink.exp.pkg.version>
         <carbon.kernel.version>4.9.10</carbon.kernel.version>
-        <carbon.identity.framework.version>7.8.550</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.84</carbon.identity.framework.version>
         <apache.felix.scr.ds.annotations.version>1.2.10</apache.felix.scr.ds.annotations.version>
         <identity.event.handler.notification.version>1.9.59</identity.event.handler.notification.version>
         <identity.inbound.auth.oauth.version>6.11.172</identity.inbound.auth.oauth.version>


### PR DESCRIPTION
This pull request updates the Magic Link Authenticator to improve tenant domain handling to support shared user direct login flows to sub-organizations. 

**Tenant Domain Handling Improvements:**

* Added the application domain (`APPLICATION_DOMAIN`) to the event properties in `triggerEvent`.
* Changed the username preprocessing method in `resolveUser` to use `preprocessUsernameWithUserResidentTenantDomain`, which ensures usernames are handled according to the user's resident tenant domain rather than the context tenant domain.

### Dependent on
- https://github.com/wso2/carbon-identity-framework/pull/7964
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3159

### Related issue
- https://github.com/wso2/product-is/issues/27371