### PR TITLE
Add Service provider uuid to properties.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticator.java
@@ -421,6 +421,10 @@ public class MagicLinkAuthenticator extends AbstractApplicationAuthenticator imp
         properties.put(MagicLinkAuthenticatorConstants.MAGIC_TOKEN, magicToken);
         properties.put(MagicLinkAuthenticatorConstants.TEMPLATE_TYPE, MagicLinkAuthenticatorConstants.EVENT_NAME);
         properties.put(IdentityEventConstants.EventProperty.APPLICATION_NAME, context.getServiceProviderName());
+        if (StringUtils.isNotBlank(context.getServiceProviderResourceId())) {
+            properties.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID,
+                    context.getServiceProviderResourceId());
+        }
         properties.put(MagicLinkAuthenticatorConstants.EXPIRYTIME, expiryTime);
         properties.put(MagicLinkAuthenticatorConstants.IS_API_BASED_AUTHENTICATION_SUPPORTED,
                 context.getProperty(IS_API_BASED));

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -163,7 +163,7 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
             otfiProperties.put(OTFI, otfi);
             context.addProperties(otfiProperties);
             magicToken = magicToken + "&" + "flowId=" + otfi;
-            triggerEvent(context, user, magicToken, expiryTime, context.getPortalUrl());
+            triggerEvent(context, user, magicToken, expiryTime, context.getPortalUrl(), context.getApplicationId());
         }
         return userInputRequiredResponse(response, MLT);
     }
@@ -212,7 +212,7 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
      * @param portalURL  The callback URL to redirect after clicking the magic link.
      */
     private void triggerEvent(FlowExecutionContext context, User user, String magicToken, String expiryTime,
-                              String portalURL) {
+                              String portalURL, String applicationId) {
 
         String eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
         Map<String, Object> properties = new HashMap<>();
@@ -225,6 +225,9 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
         properties.put(PORTAL_URL, portalURL);
         properties.put(NotificationConstants.ARBITRARY_SEND_TO, user.getAttributes().get(EMAIL_ADDRESS_CLAIM));
         properties.put(NotificationConstants.FLOW_TYPE, context.getFlowType());
+        if (StringUtils.isNotBlank(applicationId)) {
+            properties.put(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID, applicationId);
+        }
         Event identityMgtEvent = new Event(eventName, properties);
         DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;
         if (LoggerUtils.isDiagnosticLogsEnabled()) {

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/MagicLinkAuthenticatorTest.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.identity.application.authenticator.magiclink;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -52,6 +53,8 @@ import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
@@ -788,5 +791,45 @@ public class MagicLinkAuthenticatorTest {
         assertEquals(redirect, DEFAULT_SERVER_URL + "/" + ERROR_PAGE + "?" + DUMMY_QUERY_PARAMS +
                 ERROR_USER_ACCOUNT_LOCKED_QUERY_PARAMS);
         assertFalse(magicLinkAuthenticator.retryAuthenticationEnabled());
+    }
+
+    @Test(description = "triggerEvent includes SERVICE_PROVIDER_UUID when context has a service provider resource id.")
+    public void testTriggerEventIncludesServiceProviderUuid() throws Exception {
+
+        MagicLinkServiceDataHolder.getInstance().setIdentityEventService(mockIdentityEventService);
+
+        User user = new User(UUID.randomUUID().toString(), USERNAME, null);
+        user.setUserStoreDomain(USER_STORE_DOMAIN);
+        user.setTenantDomain(SUPER_TENANT_DOMAIN);
+
+        when(context.getServiceProviderName()).thenReturn(DUMMY_APP_NAME);
+        when(context.getServiceProviderResourceId()).thenReturn(DUMMY_APP_RESOURCE_ID);
+
+        magicLinkAuthenticator.triggerEvent(user, context, DUMMY_MAGIC_TOKEN, "300");
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        Mockito.verify(mockIdentityEventService).handleEvent(eventCaptor.capture());
+        assertEquals(eventCaptor.getValue().getEventProperties()
+                .get(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID), DUMMY_APP_RESOURCE_ID);
+    }
+
+    @Test(description = "triggerEvent omits SERVICE_PROVIDER_UUID when service provider resource id is blank.")
+    public void testTriggerEventOmitsServiceProviderUuidWhenBlank() throws Exception {
+
+        MagicLinkServiceDataHolder.getInstance().setIdentityEventService(mockIdentityEventService);
+
+        User user = new User(UUID.randomUUID().toString(), USERNAME, null);
+        user.setUserStoreDomain(USER_STORE_DOMAIN);
+        user.setTenantDomain(SUPER_TENANT_DOMAIN);
+
+        when(context.getServiceProviderName()).thenReturn(DUMMY_APP_NAME);
+        when(context.getServiceProviderResourceId()).thenReturn(null);
+
+        magicLinkAuthenticator.triggerEvent(user, context, DUMMY_MAGIC_TOKEN, "300");
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        Mockito.verify(mockIdentityEventService).handleEvent(eventCaptor.capture());
+        assertFalse(eventCaptor.getValue().getEventProperties()
+                .containsKey(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID));
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/test/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutorTest.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.application.authenticator.magiclink.TokenGenerat
 import org.wso2.carbon.identity.application.authenticator.magiclink.internal.MagicLinkServiceDataHolder;
 import org.wso2.carbon.identity.application.authenticator.magiclink.model.MagicLinkExecutorContextData;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
@@ -294,6 +295,33 @@ public class MagicLinkExecutorTest {
         verify(eventService).handleEvent(eventCaptor.capture());
         Event capturedEvent = eventCaptor.getValue();
         assertNull(capturedEvent.getEventProperties().get(MagicLinkAuthenticatorConstants.TEMPLATE_TYPE));
+    }
+
+    @Test
+    public void testExecuteIncludesServiceProviderUuidInEvent() throws Exception {
+
+        prepareInitiationContext();
+        String applicationId = "test-app-uuid";
+        when(context.getApplicationId()).thenReturn(applicationId);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        executor.execute(context);
+        verify(eventService).handleEvent(eventCaptor.capture());
+        assertEquals(eventCaptor.getValue().getEventProperties()
+                .get(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID), applicationId);
+    }
+
+    @Test
+    public void testExecuteOmitsServiceProviderUuidWhenApplicationIdBlank() throws Exception {
+
+        prepareInitiationContext();
+        when(context.getApplicationId()).thenReturn(null);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        executor.execute(context);
+        verify(eventService).handleEvent(eventCaptor.capture());
+        assertNull(eventCaptor.getValue().getEventProperties()
+                .get(IdentityEventConstants.EventProperty.SERVICE_PROVIDER_UUID));
     }
 
     @Test


### PR DESCRIPTION
Related Issues:

- [x] https://github.com/wso2/product-is/issues/27039

This pull request makes targeted improvements to how service provider identifiers are handled when triggering magic link authentication events. The main changes ensure that the service provider UUID is included in event properties only when available, and update method signatures and calls to support this enhancement.

**Enhancements to event property handling:**

* The `triggerEvent` method in `MagicLinkExecutor` now accepts an additional `applicationId` parameter, allowing the inclusion of the service provider UUID in event properties when available.
* The call to `triggerEvent` in `initiateMagicLink` is updated to pass the `applicationId` from the context.
* Inside `triggerEvent`, the service provider UUID is conditionally added to event properties only if `applicationId` is not blank, ensuring robustness.

**Consistency with event property population:**

* In `MagicLinkAuthenticator.java`, the service provider UUID is similarly added to event properties only if the resource ID is not blank, aligning with the new approach.