### PR TITLE
Add userstore domain for user object which is passing to trigger event

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.magiclink/src/main/java/org/wso2/carbon/identity/application/authenticator/magiclink/executor/MagicLinkExecutor.java
@@ -134,6 +134,7 @@ public class MagicLinkExecutor extends AuthenticationExecutor {
         User user = new User();
         user.setUsername(username);
         user.setTenantDomain(context.getTenantDomain());
+        user.setUserStoreDomain(context.getFlowUser().getUserStoreDomain());
         HashMap<String, String> attributes = new HashMap<>();
         attributes.put(USERNAME_CLAIM, username);
         attributes.put(EMAIL_ADDRESS_CLAIM, emailAddress);


### PR DESCRIPTION
## Changed in this PR
- $subject since this userstore domain is used to extract the user claims in [1] so that the code can get the user's configured locale value and extract the corresponding email template.

[1] https://github.com/wso2-extensions/identity-event-handler-notification/blob/12fed10b72f5701afe36cebca101d82ef62bd15e/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/util/NotificationUtil.java#L725